### PR TITLE
Fix dollar sign in TeaserV1 action title

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aem-core-components-react-base",
-  "version": "1.1.3",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aem-core-components-react-base",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "license": "Apache-2.0",
   "keywords": [
     "adobe",

--- a/src/authoring/teaser/v1/TeaserV1.test.tsx
+++ b/src/authoring/teaser/v1/TeaserV1.test.tsx
@@ -61,7 +61,7 @@ it('Renders as expected', ()=> {
 
     const content = element.find(".cmp-teaser__content");
     expect(content).toHaveLength(1);
-    
+
     //description
     const description = content.find('.cmp-teaser__description');
     expect(description).toHaveLength(1);
@@ -75,8 +75,8 @@ it('Renders as expected', ()=> {
     //title
     const title = content.find('.cmp-teaser__title');
     expect(title).toHaveLength(1);
-    const expectedHtml = `<div class=\"cmp-teaser__title\"><${defaultProps.titleType} class=\"cmp-teaser__title-text\"><a href=\"${defaultProps.linkURL}" class=\"cmp-teaser__title-link\">${defaultProps.title}</a></${defaultProps.titleType}></div>`;
-    expect(title.html()).toEqual(expectedHtml);
+    const expectedTitleHtml = `<div class=\"cmp-teaser__title\"><${defaultProps.titleType} class=\"cmp-teaser__title-text\"><a href=\"${defaultProps.linkURL}" class=\"cmp-teaser__title-link\">${defaultProps.title}</a></${defaultProps.titleType}></div>`;
+    expect(title.html()).toEqual(expectedTitleHtml);
 
 
     //image
@@ -91,9 +91,10 @@ it('Renders as expected', ()=> {
     //actions
     const actionContainer = element.find(".cmp-teaser__action-container");
     expect(actionContainer).toHaveLength(1);
+    const expectedActionContainerHtml = `<div class=\"cmp-teaser__action-container\"><a href="${defaultProps.actions[0].URL}" class="cmp-teaser__action-link">${defaultProps.actions[0].title}</a><a href="${defaultProps.actions[1].URL}" class="cmp-teaser__action-link">${defaultProps.actions[1].title}</a></div>`;
+    expect(actionContainer.html()).toEqual(expectedActionContainerHtml);
 
     const actions = actionContainer.find("a.cmp-teaser__action-link");
     expect(actions).toHaveLength(2);
-
 
 });

--- a/src/authoring/teaser/v1/TeaserV1.tsx
+++ b/src/authoring/teaser/v1/TeaserV1.tsx
@@ -43,7 +43,7 @@ export interface TeaserV1Model extends RoutedCoreComponentModel{
 }
 
 const generateLink = (props:TeaserV1Model, action:TeaserV1Action, index:number) => {
-    return <RoutedLink key={"link-" + index} isRouted={props.routed} className={props.baseCssClass + '__action-link'} to={action.URL}>${action.title}</RoutedLink>
+    return <RoutedLink key={"link-" + index} isRouted={props.routed} className={props.baseCssClass + '__action-link'} to={action.URL}>{action.title}</RoutedLink>
 }
 
 const TeaserV1Image = (props:TeaserV1Model) => {
@@ -56,7 +56,7 @@ const TeaserV1Image = (props:TeaserV1Model) => {
 
 const TeaserV1PreTitle = (props:TeaserV1Model) => <div className={props.baseCssClass + '__pretitle'}>{props.pretitle}</div>;
 
-const TeaserV1Title = (props:TeaserV1Model) => 
+const TeaserV1Title = (props:TeaserV1Model) =>
         <TitleV1 baseCssClass={props.baseCssClass + '__title'}
                  nested={true}
                  routed={props.routed}


### PR DESCRIPTION
Fixes adobe/aem-react-core-wcm-components-base#6

Removes output of dollar sign before action title on TeaserV1

## Description

Cleanup dollar sign and create corresponding unit test

## Related Issue

https://github.com/adobe/aem-react-core-wcm-components-base/issues/6

## Motivation and Context

Teaser action links output a title that does not correspond to the specification; prepending a dollar sign that, yeah, is a typo.

## How Has This Been Tested?

Extended TeaserV1.tests.tsx to check for the HTML from .cmp-teaser__action-container

Ran `npm run test` with the original code and there is a FAIL on TeaserV1.test.tsx

Then ran again `npm run test` with the changed code in TeaserV1.tsx and all tests are green.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
